### PR TITLE
Fix barcode binding type for product lookups

### DIFF
--- a/models/producto.model.php
+++ b/models/producto.model.php
@@ -127,7 +127,7 @@ class ModelProducto
 												WHERE p.codigoBarras = :codigoProducto");
 		//AND c.idAlmacen = :idAlmacen
 
-		$stmt->bindParam(":codigoProducto", $codigoProducto, PDO::PARAM_INT);
+                $stmt->bindParam(":codigoProducto", $codigoProducto, PDO::PARAM_STR);
 		//$stmt -> bindParam(":idAlmacen",$idAlmacen,PDO::PARAM_INT);
 		$stmt->execute();
 		return $stmt->fetch(PDO::FETCH_OBJ);
@@ -175,7 +175,7 @@ class ModelProducto
 												AND i.stock > 0");
 
 
-		$stmt->bindParam(":codigoProducto", $codigoProducto, PDO::PARAM_INT);
+                $stmt->bindParam(":codigoProducto", $codigoProducto, PDO::PARAM_STR);
 		$stmt->bindParam(":idAlmacen", $idAlmacen, PDO::PARAM_INT);
 		$stmt->execute();
 		return $stmt->fetch(PDO::FETCH_OBJ);


### PR DESCRIPTION
## Summary
- ensure product lookup queries bind barcode parameters as strings to support alphanumeric codes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da0ade94b88325ad590f4e9fa8e154