### PR TITLE
Add CLI tool to scaffold new modules

### DIFF
--- a/ajax/carga_de_candidatos.ajax.php
+++ b/ajax/carga_de_candidatos.ajax.php
@@ -1,0 +1,18 @@
+<?php
+
+require_once "../controllers/carga_de_candidatos.controller.php";
+require_once "../models/carga_de_candidatos.model.php";
+
+class AjaxCargaDeCandidatos
+{
+    public function ajaxMostrarCargaDeCandidatos()
+    {
+        $respuesta = ControllerCargaDeCandidatos::ctrMostrarCargaDeCandidatos();
+        echo json_encode($respuesta);
+    }
+}
+
+if (isset($_POST["mostrarCarga_de_candidatos"])) {
+    $ajax = new AjaxCargaDeCandidatos();
+    $ajax->ajaxMostrarCargaDeCandidatos();
+}

--- a/controllers/carga_de_candidatos.controller.php
+++ b/controllers/carga_de_candidatos.controller.php
@@ -1,0 +1,12 @@
+<?php
+
+class ControllerCargaDeCandidatos
+{
+    /**
+     * Punto de entrada para listar información del módulo Carga de candidatos.
+     */
+    public static function ctrMostrarCargaDeCandidatos()
+    {
+        return ModelCargaDeCandidatos::mdlMostrarCargaDeCandidatos();
+    }
+}

--- a/docs/crear-nuevos-modulos.md
+++ b/docs/crear-nuevos-modulos.md
@@ -1,0 +1,41 @@
+# Creación rápida de módulos
+
+Este proyecto incluye muchos módulos (controladores, modelos, vistas, archivos AJAX y scripts de JavaScript). Para facilitar la creación de nuevas características se añadió un pequeño generador de scaffolding accesible desde la línea de comandos.
+
+## Requisitos previos
+
+* Tener PHP instalado y disponible en la línea de comandos.
+* Ejecutar los comandos desde la raíz del proyecto (`/workspace/neu`).
+
+## Uso
+
+```bash
+php scripts/create_module.php NombreModulo "Título legible"
+```
+
+Donde:
+
+* `NombreModulo` es un identificador sin espacios (el script normaliza mayúsculas, guiones o espacios y los convierte en `snake_case`).
+* `"Título legible"` es opcional y se muestra en la vista generada.
+
+Ejemplo:
+
+```bash
+php scripts/create_module.php Reportes "Panel de reportes"
+```
+
+El comando anterior crea automáticamente los siguientes archivos si no existen:
+
+* `controllers/reportes.controller.php`
+* `models/reportes.model.php`
+* `ajax/reportes.ajax.php`
+* `views/modules/reportes.php`
+* `views/js/reportes.js`
+
+Cada archivo contiene una plantilla mínima para comenzar a trabajar.
+
+## Qué hacer después
+
+1. Completar la lógica del modelo y del controlador según la funcionalidad requerida.
+2. Ajustar la vista (`views/modules/<modulo>.php`) y el JavaScript (`views/js/<modulo>.js`).
+3. Registrar nuevas rutas o entradas de menú en caso de ser necesario.

--- a/models/carga_de_candidatos.model.php
+++ b/models/carga_de_candidatos.model.php
@@ -1,0 +1,13 @@
+<?php
+
+require_once "conexion.php";
+
+class ModelCargaDeCandidatos
+{
+    public static function mdlMostrarCargaDeCandidatos()
+    {
+        $stmt = Conexion::conectar()->prepare("SELECT 1");
+        $stmt->execute();
+        return $stmt->fetch();
+    }
+}

--- a/scripts/create_module.php
+++ b/scripts/create_module.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * CLI script to scaffold a new module for the application.
+ *
+ * Usage:
+ *   php scripts/create_module.php NombreModulo "Título legible"
+ */
+
+declare(strict_types=1);
+
+$usage = "Usage: php scripts/create_module.php <ModuleName> [Readable Title]\n";
+
+if (PHP_SAPI !== 'cli') {
+    fwrite(STDERR, "This script must be executed from the command line.\n");
+    exit(1);
+}
+
+if ($argc < 2) {
+    fwrite(STDERR, $usage);
+    exit(1);
+}
+
+$rawName = $argv[1];
+
+$normalized = preg_replace('/[^a-zA-Z0-9]+/', '_', $rawName);
+$normalized = trim($normalized ?? '', '_');
+
+if ($normalized === '') {
+    fwrite(STDERR, "The provided module name does not contain valid characters.\n");
+    exit(1);
+}
+
+$slug = strtolower($normalized);
+$title = $argv[2] ?? ucwords(str_replace('_', ' ', $slug));
+$camel = str_replace(' ', '', ucwords(str_replace('_', ' ', $slug)));
+
+$root = realpath(__DIR__ . '/..');
+
+if ($root === false) {
+    fwrite(STDERR, "Unable to resolve project root directory.\n");
+    exit(1);
+}
+
+$placeholders = [
+    '{{CONTROLLER_CLASS}}' => 'Controller' . $camel,
+    '{{MODEL_CLASS}}' => 'Model' . $camel,
+    '{{AJAX_CLASS}}' => 'Ajax' . $camel,
+    '{{TITLE}}' => $title,
+    '{{SLUG}}' => $slug,
+    '{{NORMALIZED}}' => $normalized,
+    '{{CAMEL}}' => $camel,
+];
+
+$templates = [
+    "controllers/{$slug}.controller.php" => <<<'PHP_CONTROLLER'
+<?php
+
+class {{CONTROLLER_CLASS}}
+{
+    /**
+     * Punto de entrada para listar información del módulo {{TITLE}}.
+     */
+    public static function ctrMostrar{{CAMEL}}()
+    {
+        return {{MODEL_CLASS}}::mdlMostrar{{CAMEL}}();
+    }
+}
+PHP_CONTROLLER,
+    "models/{$slug}.model.php" => <<<'PHP_MODEL'
+<?php
+
+require_once "conexion.php";
+
+class {{MODEL_CLASS}}
+{
+    public static function mdlMostrar{{CAMEL}}()
+    {
+        $stmt = Conexion::conectar()->prepare("SELECT 1");
+        $stmt->execute();
+        return $stmt->fetch();
+    }
+}
+PHP_MODEL,
+    "ajax/{$slug}.ajax.php" => <<<'PHP_AJAX'
+<?php
+
+require_once "../controllers/{{SLUG}}.controller.php";
+require_once "../models/{{SLUG}}.model.php";
+
+class {{AJAX_CLASS}}
+{
+    public function ajaxMostrar{{CAMEL}}()
+    {
+        $respuesta = {{CONTROLLER_CLASS}}::ctrMostrar{{CAMEL}}();
+        echo json_encode($respuesta);
+    }
+}
+
+if (isset($_POST["mostrar{{NORMALIZED}}"])) {
+    $ajax = new {{AJAX_CLASS}}();
+    $ajax->ajaxMostrar{{CAMEL}}();
+}
+PHP_AJAX,
+    "views/modules/{$slug}.php" => <<<'PHP_VIEW'
+<div class="content-wrapper">
+    <section class="content-header">
+        <h1>{{TITLE}}</h1>
+    </section>
+
+    <section class="content">
+        <div class="box">
+            <div class="box-body">
+                <!-- Contenido del módulo {{TITLE}} -->
+            </div>
+        </div>
+    </section>
+</div>
+PHP_VIEW,
+    "views/js/{$slug}.js" => <<<'JS'
+$(function () {
+    console.log('Módulo {{TITLE}} listo');
+});
+JS,
+];
+
+$report = [];
+
+foreach ($templates as $relative => $template) {
+    $target = $root . DIRECTORY_SEPARATOR . $relative;
+
+    if (file_exists($target)) {
+        $report[] = [
+            'path' => $relative,
+            'status' => 'exists',
+        ];
+        continue;
+    }
+
+    $directory = dirname($target);
+
+    if (!is_dir($directory) && !mkdir($directory, 0775, true) && !is_dir($directory)) {
+        fwrite(STDERR, "Cannot create directory: {$directory}\n");
+        exit(1);
+    }
+
+    $content = strtr($template, $placeholders);
+
+    file_put_contents($target, $content);
+
+    $report[] = [
+        'path' => $relative,
+        'status' => 'created',
+    ];
+}
+
+foreach ($report as $entry) {
+    fwrite(STDOUT, sprintf("[%s] %s\n", strtoupper($entry['status']), $entry['path']));
+}

--- a/views/js/carga_de_candidatos.js
+++ b/views/js/carga_de_candidatos.js
@@ -1,0 +1,3 @@
+$(function () {
+    console.log('Módulo Carga de candidatos listo');
+});

--- a/views/modules/carga_de_candidatos.php
+++ b/views/modules/carga_de_candidatos.php
@@ -1,0 +1,13 @@
+<div class="content-wrapper">
+    <section class="content-header">
+        <h1>Carga de candidatos</h1>
+    </section>
+
+    <section class="content">
+        <div class="box">
+            <div class="box-body">
+                <!-- Contenido del módulo Carga de candidatos -->
+            </div>
+        </div>
+    </section>
+</div>


### PR DESCRIPTION
## Summary
- add a command-line scaffolding script that creates controller, model, AJAX, view, and JS files for a new module name
- document the workflow for generating and customizing modules in docs/crear-nuevos-modulos.md

## Testing
- php -l scripts/create_module.php

------
https://chatgpt.com/codex/tasks/task_e_68da0e7baf948325aa18d01fa19a7c88